### PR TITLE
zip: Fix to deal with clang not allowing memset without string.h

### DIFF
--- a/Formula/zip.rb
+++ b/Formula/zip.rb
@@ -44,6 +44,9 @@ class Zip < Formula
   end
 
   def install
+    if OS.mac?
+      system "make", "-f", "unix/Makefile", "CC=#{ENV.cc} -Wno-implicit-function-declaration", "flags"
+    end
     system "make", "-f", "unix/Makefile", "CC=#{ENV.cc}", "generic"
     system "make", "-f", "unix/Makefile", "BINDIR=#{bin}", "MANDIR=#{man1}", "install"
   end


### PR DESCRIPTION
Zip attempts to link memset without including string.h, but clang is having none of that so fails a configure test, which causes -DZMEM to be defined, which sets it's own memset, which then failing during normal compile because there IS a memset.

This gets around it for now by using the OS.mac? check to presume it's clang, but the same issue would happen (I presume) with clang on linux.

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you ensured that your commits follow the [commit style guide](https://docs.brew.sh/Formula-Cookbook#commit)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Does your build pass `brew audit --strict <formula>` (after doing `brew install --build-from-source <formula>`)? If this is a new formula, does it pass `brew audit --new <formula>`?

-----
